### PR TITLE
Backups fix 4.4.1

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -17,8 +17,8 @@ android {
         targetSdkVersion 33
         minSdkVersion 21
 
-        versionName '4.4.0'
-        versionCode 103
+        versionName '4.4.1'
+        versionCode 104
     }
 
     dexOptions {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     package="com.btcontract.walletfiat">
 
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.INTERNET"/>

--- a/app/src/main/java/com/btcontract/walletfiat/WalletApp.scala
+++ b/app/src/main/java/com/btcontract/walletfiat/WalletApp.scala
@@ -14,7 +14,7 @@ import android.widget.{EditText, Toast}
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.multidex.MultiDex
 import BaseActivity.StringOps
-import com.btcontract.walletfiat.utils.{AwaitService, DelayedNotification, LocalBackup}
+import com.btcontract.walletfiat.utils.{AwaitService, LocalBackup}
 import com.btcontract.walletfiat.sqlite.DBInterfaceSQLiteAndroidMisc
 import com.btcontract.walletfiat.utils.DelayedNotification
 import com.btcontract.walletfiat.R.string._
@@ -120,7 +120,7 @@ object WalletApp {
     try LNParams.fiatRates.becomeShutDown catch none
     try LNParams.feeRates.becomeShutDown catch none
     try LNParams.cm.becomeShutDown catch none
-    // Make non-alive and non-operational
+    // Make non-alive and non-operational`
     LNParams.secret = null
     txDataBag = null
   }

--- a/sign-apk.sh
+++ b/sign-apk.sh
@@ -3,7 +3,7 @@
 set -xe
 echo $PATH
 zipalign=~/Android/Sdk/build-tools/30.0.3/zipalign
-VERSION=4.3.0
+VERSION=4.4.1
 rm app/build/outputs/apk/release/Valet-$VERSION-aligned.apk || true
 $zipalign -v 4 app/build/outputs/apk/release/Valet-$VERSION.apk app/build/outputs/apk/release/Valet-$VERSION-aligned.apk
 apksigner sign --ks release.keystore --ks-key-alias release --v1-signing-enabled true --v2-signing-enabled true app/build/outputs/apk/release/Valet-$VERSION-aligned.apk


### PR DESCRIPTION
The patch to the previous update as we faced issues on ChromeOS and GrapheneOS.

* Now backup worker doesn't creates millions of files even in default Download directory
* Now wallet will write backups to custom directory even if OS doesn't provide permissions to write to external storage (SAF URI contains persistent permissions for that)